### PR TITLE
Define minimal address-space mapping rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ ROOT_TASK := $(BUILD_DIR)/bootstrap.elf
 GENERATED_DIR := $(BUILD_DIR)/generated
 KERNEL_VERSION_H := $(GENERATED_DIR)/version.h
 KERNEL_VERSION_TXT := $(BUILD_DIR)/kernel_version.txt
+ROOT_TASK_EXTRA_CFLAGS ?=
+FAULT_ADDR ?= 0xffffffff80000000
 
 include version/version.mk
 
@@ -62,7 +64,7 @@ $(KERNEL): kernel/src/main.c kernel/include/limine.h kernel/linker.ld $(KERNEL_V
 		-I$(GENERATED_DIR) \
 		-o $(KERNEL)
 
-$(ROOT_TASK): root-task/src/main.c
+$(ROOT_TASK): FORCE root-task/src/main.c
 	@mkdir -p $(BUILD_DIR)
 	clang root-task/src/main.c \
 		-std=c23 \
@@ -79,6 +81,7 @@ $(ROOT_TASK): root-task/src/main.c
 		-fuse-ld=lld \
 		-Wall \
 		-Wextra \
+		$(ROOT_TASK_EXTRA_CFLAGS) \
 		-Wl,-m,elf_x86_64 \
 		-Wl,-e,_start \
 		-Wl,--build-id=none \
@@ -133,6 +136,11 @@ smoke: run
 	@grep -q "kernel: entering user mode" $(BOOTLOG)
 	@grep -q "user: hello lumen" $(BOOTLOG)
 	@grep -q "kernel: syscall handled" $(BOOTLOG)
+	@grep -q "kernel: user fault page" $(BOOTLOG)
+	@grep -q "kernel: user fault addr = $(FAULT_ADDR)" $(BOOTLOG)
+
+smoke-guard:
+	$(MAKE) ROOT_TASK_EXTRA_CFLAGS=-DROOT_TASK_FAULT_GUARD_PAGE FAULT_ADDR=0x00007ffffffdf010 smoke
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/docs/spec/bootstrap-protocol.md
+++ b/docs/spec/bootstrap-protocol.md
@@ -110,24 +110,37 @@ The kernel creates the first userspace address space and maps only the minimum r
    - executable segments mapped RX
    - read-only data mapped R
    - writable data/BSS mapped RW
+   - writable+executable user pages are invalid
 
 2. initial user stack  
    - mapped RW
    - at least one guard page
    - initial size implementation-defined for bring-up
    - recommended initial size: 64 KiB
+   - the guard page remains unmapped and must fault on access
 
 3. BootInfo mapping  
    - mapped read-only
    - present at entry
    - virtual address passed in a register at task entry
 
-### 5.2 Optional mappings
+### 5.2 Mapping rules
+
+The kernel must expose explicit mapping classes rather than a generic ambient mapping model.
+
+- kernel-only mappings are never tagged user-accessible
+- user mappings are created as read-only, read-write, or executable
+- user read-write mappings must not also be executable
+- user access to kernel-only pages must fault
+- the initial user stack is a bounded mapping with an unmapped guard page
+- BootInfo remains read-only for the first task
+
+### 5.3 Optional mappings
 
 - optional read-only mappings for boot modules are allowed
 - default preference: boot modules are passed as `VMO` capabilities and mapped by userspace explicitly
 
-### 5.3 Hard rules
+### 5.4 Hard rules
 
 - kernel memory is not mapped into userspace
 - no direct identity map of physical memory is exposed to the first task

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -17,7 +17,10 @@
 #define KERNEL_STACK_SIZE (64 * 1024ULL)
 #define USER_ADDRESS_TOP 0x0000800000000000ULL
 #define USER_STACK_SIZE (64 * 1024ULL)
+#define USER_STACK_GUARD_SIZE PAGE_SIZE
+#define USER_STACK_TOTAL_SIZE (USER_STACK_SIZE + USER_STACK_GUARD_SIZE)
 #define USER_STACK_TOP 0x00007fffffff0000ULL
+#define KERNEL_ADDRESS_BASE 0xffff800000000000ULL
 #define PAGE_SIZE 0x1000ULL
 #define PAGE_PRESENT 0x001ULL
 #define PAGE_WRITABLE 0x002ULL
@@ -103,6 +106,7 @@ struct root_task_launch_frame {
 };
 
 struct root_task_launch_state {
+    uint64_t stack_guard_base;
     uint64_t stack_base;
     uint64_t stack_top;
     struct root_task_context context;
@@ -176,6 +180,12 @@ static uint64_t kernel_gdt[7] __attribute__((aligned(16))) = {
 };
 static struct tss64 kernel_tss;
 static struct idt_entry kernel_idt[256];
+
+enum user_mapping_access {
+    USER_MAPPING_READ_ONLY = 0,
+    USER_MAPPING_READ_WRITE = 1,
+    USER_MAPPING_EXECUTABLE = 2,
+};
 
 static void outb(uint16_t port, uint8_t value) {
     __asm__ volatile("outb %0, %1" : : "a"(value), "Nd"(port) : "memory");
@@ -323,6 +333,19 @@ static const char *path_basename(const char *path) {
     }
 
     return base;
+}
+
+static const char *user_mapping_access_name(enum user_mapping_access access) {
+    switch (access) {
+        case USER_MAPPING_READ_ONLY:
+            return "read-only";
+        case USER_MAPPING_READ_WRITE:
+            return "read-write";
+        case USER_MAPPING_EXECUTABLE:
+            return "executable";
+    }
+
+    return "unknown";
 }
 
 // PMM functions
@@ -720,7 +743,7 @@ static uint64_t translate_kernel_vaddr_to_phys(uint64_t vaddr) {
     return (pte & PAGE_ADDR_MASK) | (vaddr & 0xfffULL);
 }
 
-static const char *map_user_page(uint64_t vaddr, uint64_t phys, uint64_t flags) {
+static const char *map_page_at(uint64_t vaddr, uint64_t phys, uint64_t flags, int user_access) {
     uint64_t pml4_phys = read_cr3() & ~0xfffULL;
     uint64_t *pml4 = (uint64_t *)phys_to_hhdm(pml4_phys);
     uint64_t pml4_index = (vaddr >> 39) & 0x1ffULL;
@@ -737,40 +760,62 @@ static const char *map_user_page(uint64_t vaddr, uint64_t phys, uint64_t flags) 
         return "page alignment bad";
     }
 
-    if (pml4_index == 0) {
-        if (user_low_pdpt_phys == 0) {
-            new_table = allocate_page_table();
-            if (new_table == 0) {
-                return "page table pool exhausted";
-            }
-            user_low_pdpt_phys = translate_kernel_vaddr_to_phys((uint64_t)new_table);
+    if (user_access) {
+        if (!user_vaddr_plausible(vaddr, PAGE_SIZE)) {
+            return "user vaddr bad";
+        }
+
+        if (pml4_index == 0) {
             if (user_low_pdpt_phys == 0) {
-                return "page table phys missing";
+                new_table = allocate_page_table();
+                if (new_table == 0) {
+                    return "page table pool exhausted";
+                }
+                user_low_pdpt_phys = translate_kernel_vaddr_to_phys((uint64_t)new_table);
+                if (user_low_pdpt_phys == 0) {
+                    return "page table phys missing";
+                }
             }
-        }
-        pml4[pml4_index] = user_low_pdpt_phys | PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER;
-    } else if (pml4_index == 0x0ffULL) {
-        if (user_high_pdpt_phys == 0) {
+            pml4[pml4_index] = user_low_pdpt_phys | PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER;
+        } else if (pml4_index == 0x0ffULL) {
+            if (user_high_pdpt_phys == 0) {
+                new_table = allocate_page_table();
+                if (new_table == 0) {
+                    return "page table pool exhausted";
+                }
+                user_high_pdpt_phys = translate_kernel_vaddr_to_phys((uint64_t)new_table);
+                if (user_high_pdpt_phys == 0) {
+                    return "page table phys missing";
+                }
+            }
+            pml4[pml4_index] = user_high_pdpt_phys | PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER;
+        } else if ((pml4[pml4_index] & PAGE_PRESENT) == 0) {
             new_table = allocate_page_table();
             if (new_table == 0) {
                 return "page table pool exhausted";
             }
-            user_high_pdpt_phys = translate_kernel_vaddr_to_phys((uint64_t)new_table);
-            if (user_high_pdpt_phys == 0) {
+            new_table_phys = translate_kernel_vaddr_to_phys((uint64_t)new_table);
+            if (new_table_phys == 0) {
                 return "page table phys missing";
             }
+            pml4[pml4_index] = new_table_phys | PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER;
         }
-        pml4[pml4_index] = user_high_pdpt_phys | PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER;
-    } else if ((pml4[pml4_index] & PAGE_PRESENT) == 0) {
-        new_table = allocate_page_table();
-        if (new_table == 0) {
-            return "page table pool exhausted";
+    } else {
+        if (vaddr < KERNEL_ADDRESS_BASE) {
+            return "kernel vaddr bad";
         }
-        new_table_phys = translate_kernel_vaddr_to_phys((uint64_t)new_table);
-        if (new_table_phys == 0) {
-            return "page table phys missing";
+
+        if ((pml4[pml4_index] & PAGE_PRESENT) == 0) {
+            new_table = allocate_page_table();
+            if (new_table == 0) {
+                return "page table pool exhausted";
+            }
+            new_table_phys = translate_kernel_vaddr_to_phys((uint64_t)new_table);
+            if (new_table_phys == 0) {
+                return "page table phys missing";
+            }
+            pml4[pml4_index] = new_table_phys | PAGE_PRESENT | PAGE_WRITABLE;
         }
-        pml4[pml4_index] = new_table_phys | PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER;
     }
 
     pdpt = (uint64_t *)phys_to_hhdm(pml4[pml4_index] & PAGE_ADDR_MASK);
@@ -783,7 +828,7 @@ static const char *map_user_page(uint64_t vaddr, uint64_t phys, uint64_t flags) 
         if (new_table_phys == 0) {
             return "page table phys missing";
         }
-        pdpt[pdpt_index] = new_table_phys | PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER;
+        pdpt[pdpt_index] = new_table_phys | PAGE_PRESENT | PAGE_WRITABLE | (user_access ? PAGE_USER : 0);
     } else if ((pdpt[pdpt_index] & PAGE_HUGE) != 0) {
         return "pdpt huge page conflict";
     }
@@ -798,18 +843,39 @@ static const char *map_user_page(uint64_t vaddr, uint64_t phys, uint64_t flags) 
         if (new_table_phys == 0) {
             return "page table phys missing";
         }
-        pd[pd_index] = new_table_phys | PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER;
+        pd[pd_index] = new_table_phys | PAGE_PRESENT | PAGE_WRITABLE | (user_access ? PAGE_USER : 0);
     } else if ((pd[pd_index] & PAGE_HUGE) != 0) {
         return "pd huge page conflict";
     }
 
     pt = (uint64_t *)phys_to_hhdm(pd[pd_index] & PAGE_ADDR_MASK);
-    pt[pt_index] = (phys & ~0xfffULL) | PAGE_PRESENT | PAGE_USER | flags;
+    pt[pt_index] = (phys & ~0xfffULL) | PAGE_PRESENT | (user_access ? PAGE_USER : 0) | flags;
     __asm__ volatile("invlpg (%0)" : : "r"((void *)vaddr) : "memory");
     return 0;
 }
 
-static const char *map_user_range(uint64_t vaddr, uint64_t kernel_buffer, uint64_t size, uint64_t flags) {
+static const char *map_kernel_only_page(uint64_t vaddr, uint64_t phys, uint64_t flags) __attribute__((unused));
+static const char *map_kernel_only_page(uint64_t vaddr, uint64_t phys, uint64_t flags) {
+    return map_page_at(vaddr, phys, flags, 0);
+}
+
+static const char *map_user_read_only_page(uint64_t vaddr, uint64_t phys) {
+    return map_page_at(vaddr, phys, PAGE_NX, 1);
+}
+
+static const char *map_user_read_write_page(uint64_t vaddr, uint64_t phys) {
+    return map_page_at(vaddr, phys, PAGE_WRITABLE | PAGE_NX, 1);
+}
+
+static const char *map_user_executable_page(uint64_t vaddr, uint64_t phys) {
+    return map_page_at(vaddr, phys, 0, 1);
+}
+
+static const char *map_user_range_with_access(
+    uint64_t vaddr,
+    uint64_t kernel_buffer,
+    uint64_t size,
+    enum user_mapping_access access) {
     uint64_t current_vaddr = align_down(vaddr, PAGE_SIZE);
     uint64_t buffer_page = align_down(kernel_buffer, PAGE_SIZE);
     uint64_t end_vaddr = align_up(vaddr + size, PAGE_SIZE);
@@ -822,7 +888,20 @@ static const char *map_user_range(uint64_t vaddr, uint64_t kernel_buffer, uint64
             return "user backing phys missing";
         }
 
-        error = map_user_page(current_vaddr, phys, flags);
+        switch (access) {
+            case USER_MAPPING_READ_ONLY:
+                error = map_user_read_only_page(current_vaddr, phys);
+                break;
+            case USER_MAPPING_READ_WRITE:
+                error = map_user_read_write_page(current_vaddr, phys);
+                break;
+            case USER_MAPPING_EXECUTABLE:
+                error = map_user_executable_page(current_vaddr, phys);
+                break;
+            default:
+                return "user mapping access invalid";
+        }
+
         if (error != 0) {
             return error;
         }
@@ -984,14 +1063,15 @@ static const char *map_root_task_segments(const struct limine_file *module, uint
 }
 
 static const char *prepare_root_task_launch_state(uint64_t entry, uint64_t *rsp_out) {
-    uint64_t stack_base = USER_STACK_TOP - USER_STACK_SIZE;
+    uint64_t stack_guard_base = USER_STACK_TOP - USER_STACK_TOTAL_SIZE;
+    uint64_t stack_base = stack_guard_base + USER_STACK_GUARD_SIZE;
     uint64_t initial_rsp;
 
     if (USER_STACK_TOP > USER_ADDRESS_TOP) {
         return "stack top outside user range";
     }
 
-    if (stack_base < 0x1000 || stack_base >= USER_STACK_TOP) {
+    if (stack_guard_base < 0x1000 || stack_guard_base >= USER_STACK_TOP) {
         return "stack range invalid";
     }
 
@@ -1001,6 +1081,7 @@ static const char *prepare_root_task_launch_state(uint64_t entry, uint64_t *rsp_
     }
 
     memory_zero(root_task_stack_pages, USER_STACK_SIZE);
+    root_task_launch_state.stack_guard_base = stack_guard_base;
     root_task_launch_state.stack_base = stack_base;
     root_task_launch_state.stack_top = USER_STACK_TOP;
 
@@ -1034,7 +1115,7 @@ static const char *install_root_task_user_mappings(const struct limine_file *mod
 
     for (index = 0; index < ehdr->e_phnum; ++index) {
         const struct elf64_phdr *phdr = &phdrs[index];
-        uint64_t segment_flags = 0;
+        enum user_mapping_access access;
         uint64_t segment_vaddr;
         uint64_t segment_size;
         uint64_t image_offset;
@@ -1047,11 +1128,16 @@ static const char *install_root_task_user_mappings(const struct limine_file *mod
         segment_size = align_up((phdr->p_vaddr - segment_vaddr) + phdr->p_memsz, PAGE_SIZE);
         image_offset = segment_vaddr - root_task_image.base_vaddr;
 
-        if (phdr->p_flags & PF_W) {
-            segment_flags |= PAGE_WRITABLE;
+        if ((phdr->p_flags & PF_W) != 0 && (phdr->p_flags & PF_X) != 0) {
+            return "user W+X forbidden";
         }
-        if ((phdr->p_flags & PF_X) == 0) {
-            segment_flags |= PAGE_NX;
+
+        if ((phdr->p_flags & PF_W) != 0) {
+            access = USER_MAPPING_READ_WRITE;
+        } else if ((phdr->p_flags & PF_X) != 0) {
+            access = USER_MAPPING_EXECUTABLE;
+        } else {
+            access = USER_MAPPING_READ_ONLY;
         }
 
         if (image_offset > ROOT_TASK_IMAGE_CAPACITY || segment_size > ROOT_TASK_IMAGE_CAPACITY - image_offset) {
@@ -1062,12 +1148,16 @@ static const char *install_root_task_user_mappings(const struct limine_file *mod
             return "user image vaddr bad";
         }
 
+        serial_write_string("kernel: user segment map ");
+        serial_write_string(user_mapping_access_name(access));
+        serial_write_string("\n");
+
         {
-            const char *error = map_user_range(
+            const char *error = map_user_range_with_access(
                 segment_vaddr,
                 (uint64_t)(root_task_image_pages + image_offset),
                 segment_size,
-                segment_flags);
+                access);
             if (error != 0) {
                 return error;
             }
@@ -1079,11 +1169,11 @@ static const char *install_root_task_user_mappings(const struct limine_file *mod
     }
 
     {
-        const char *error = map_user_range(
-        root_task_launch_state.stack_base,
-        (uint64_t)root_task_stack_pages,
-        USER_STACK_SIZE,
-        PAGE_WRITABLE);
+        const char *error = map_user_range_with_access(
+            root_task_launch_state.stack_base,
+            (uint64_t)root_task_stack_pages,
+            USER_STACK_SIZE,
+            USER_MAPPING_READ_WRITE);
         if (error != 0) {
             return error;
         }
@@ -1164,8 +1254,14 @@ __attribute__((noreturn)) void handle_user_general_protection(uint64_t error_cod
     halt_forever();
 }
 
-__attribute__((noreturn)) void handle_user_page_fault(void) {
+__attribute__((noreturn)) void handle_user_page_fault(uint64_t fault_address, uint64_t error_code) {
     serial_write_string("kernel: user fault page\n");
+    serial_write_string("kernel: user fault addr = ");
+    serial_write_hex(fault_address);
+    serial_write_string("\n");
+    serial_write_string("kernel: user fault code = ");
+    serial_write_hex(error_code);
+    serial_write_string("\n");
     halt_forever();
 }
 
@@ -1184,7 +1280,8 @@ __attribute__((naked)) void user_general_protection_stub(void) {
 
 __attribute__((naked)) void user_page_fault_stub(void) {
     __asm__ volatile(
-        "addq $8, %rsp\n"
+        "movq %cr2, %rdi\n"
+        "popq %rsi\n"
         "cld\n"
         "call handle_user_page_fault\n");
 }
@@ -1356,6 +1453,12 @@ __attribute__((noreturn)) void kernel_main(void) {
     }
 
     serial_write_string("kernel: root task stack allocated\n");
+    serial_write_string("kernel: root task stack guard base = ");
+    serial_write_hex(root_task_launch_state.stack_guard_base);
+    serial_write_string("\n");
+    serial_write_string("kernel: root task stack base = ");
+    serial_write_hex(root_task_launch_state.stack_base);
+    serial_write_string("\n");
     serial_write_string("kernel: root task stack top = ");
     serial_write_hex(root_task_launch_state.stack_top);
     serial_write_string("\n");

--- a/root-task/src/main.c
+++ b/root-task/src/main.c
@@ -1,12 +1,29 @@
 const char hello_message[] = "user: hello lumen\n";
 
+#define USER_STACK_TOP 0x00007fffffff0000ULL
+#define USER_STACK_SIZE (64 * 1024ULL)
+#define USER_STACK_GUARD_SIZE 0x1000ULL
+#define USER_STACK_BASE (USER_STACK_TOP - USER_STACK_SIZE)
+#define USER_STACK_GUARD_BASE (USER_STACK_BASE - USER_STACK_GUARD_SIZE)
+#define KERNEL_ADDRESS_BASE 0xffffffff80000000ULL
+#if defined(ROOT_TASK_FAULT_GUARD_PAGE)
+#define FAULT_ADDRESS (USER_STACK_GUARD_BASE + 0x10ULL)
+#else
+#define FAULT_ADDRESS KERNEL_ADDRESS_BASE
+#endif
+
 __attribute__((noreturn, naked)) void _start(void) {
     __asm__ volatile(
-        "lea hello_message(%rip), %rdi\n"
-        "mov $18, %rsi\n"
-        "mov $1, %rax\n"
+        "lea hello_message(%%rip), %%rdi\n"
+        "mov $18, %%rsi\n"
+        "mov $1, %%rax\n"
         "int $0x80\n"
+        "movabs $%c0, %%rdi\n"
+        "movb $0x41, (%%rdi)\n"
         "1:\n"
         "pause\n"
-        "jmp 1b\n");
+        "jmp 1b\n"
+        :
+        : "i"(FAULT_ADDRESS)
+        : "rdi", "memory");
 }

--- a/run-qemu.sh
+++ b/run-qemu.sh
@@ -5,16 +5,24 @@ mkdir -p build
 rm -f build/boot.log
 
 status=0
+set +e
 timeout --foreground 20s qemu-system-x86_64 \
   -boot d \
   -cdrom build/lumenos.iso \
-  -serial file:build/boot.log \
+  -serial stdio \
   -monitor none \
   -display none \
-  -no-reboot || status=$?
+  -no-reboot 2>&1 | tee build/boot.log
+status=${PIPESTATUS[0]:-1}
+tee_status=${PIPESTATUS[1]:-0}
+set -e
 
 if [ "$status" -ne 0 ] && [ "$status" -ne 124 ]; then
   exit "$status"
+fi
+
+if [ "$tee_status" -ne 0 ]; then
+  exit "$tee_status"
 fi
 
 for _ in 1 2 3 4 5; do


### PR DESCRIPTION
# Pull Request

## Summary

This change defines the minimal address-space and mapping rules needed for
kernel/user isolation in the first userspace bring-up path.

The kernel now treats mappings as explicit classes instead of a generic
ambient memory model:

- kernel-only mappings remain kernel-only
- user mappings are created as read-only, read-write, or executable
- user write+execute combinations are rejected
- the initial user stack includes an unmapped guard page
- user faults on kernel addresses and guard pages are observable and logged

The bootstrap task still runs as a minimal bring-up binary, but it now proves
the isolation rules by triggering a deliberate user fault after the syscall
path completes.

## Changes

- add explicit mapping helpers for kernel-only, user read-only, user
  read-write, and user executable pages
- reject user mappings that request both write and execute
- keep user mappings out of the kernel address range
- add guard-page placement for the initial user stack
- log page-fault address and error code in the kernel trap handler
- update the bootstrap task so it faults intentionally after the hello/syscall
  path, proving kernel-address access is denied
- add a guard-page smoke mode for the stack fault path
- stream QEMU serial output into `build/boot.log` so smoke tests can inspect
  guest output reliably
- document the mapping contract in the bootstrap protocol spec without POSIX
  terminology as the primary model

## Expected Boot Markers

```text
kernel: early boot ok | version 0.1.0:000xx
kernel: modules request ok
kernel: module count = 1
kernel: root task module found
kernel: root task elf valid
kernel: root task map begin
kernel: root task load segments = N
kernel: user segment map read-only
kernel: user segment map executable
kernel: entering user mode
user: hello lumen
kernel: syscall handled
kernel: user fault page
kernel: user fault addr = 0xffffffff80000000
kernel: user fault code = 0x0000000000000007
```

Guard-page smoke mode should instead fault at the stack guard address:

```text
kernel: user fault addr = 0x00007ffffffdf010
kernel: user fault code = 0x0000000000000006
```

## Verification

```bash
make smoke
make smoke-guard
```

## Notes

- this is still the early bring-up implementation, not a full object-backed
  virtual memory subsystem
- copy-on-write, shared libraries, demand paging, and POSIX compatibility are
  intentionally out of scope


---
@codex review using docs/review/codex-review-policy.md

---
Closes #14 
